### PR TITLE
Update k6_payment_burst.js to align with SLA metrics

### DIFF
--- a/k6_payment_burst.js
+++ b/k6_payment_burst.js
@@ -9,7 +9,7 @@ export let options = {
         { duration: `${__ENV.RAMP_DOWN_DURATION || '30s'}`, target: 0 },
     ],
     thresholds: {
-        'http_req_duration': ['p(95)<500'], // 95% of requests should be below 500ms
+        'http_req_duration': ['p(95)<2000'], // 95% of requests should be below 2 seconds
         'http_req_failed': ['rate<0.01'], // Less than 1% failed requests
     },
 };


### PR DESCRIPTION
This pull request updates the k6_payment_burst.js load test script to align with the SLA metrics documented for NovaPay. Changes include:
- Adjusted 95th percentile response time threshold to 2 seconds
- Ensured error rate less than 1%
- Maintained randomized payment data generation and checks
- Environment variable control for load stages and pacing

These changes ensure load tests reflect realistic performance expectations and help monitor system responsiveness and stability under load.